### PR TITLE
Task 5.1: Prisen bliver nu også dynamisk vist inkl. moms på alle siderne.

### DIFF
--- a/src/components/addNewScooter/AddNewScooter.js
+++ b/src/components/addNewScooter/AddNewScooter.js
@@ -10,6 +10,7 @@ import {
   Form,
   InputGroup,
   FormGroup,
+  FormText,
   Input,
   Button,
   Alert,
@@ -218,6 +219,11 @@ function AddNewScooter() {
               Her indtaster du elscooterens pris uden moms i DKK. Fx 22999,95.
             </Tooltip>
           </InputGroup>
+          {price > 0 && (
+            <FormText color="muted">
+              Pris inkl. moms vil blive {price * 1.25} DKK.
+            </FormText>
+          )}
         </FormGroup>
         <FormGroup>
           <InputGroup>

--- a/src/components/addNewSparepart/AddNewSparepart.js
+++ b/src/components/addNewSparepart/AddNewSparepart.js
@@ -10,6 +10,7 @@ import {
   Form,
   InputGroup,
   FormGroup,
+  FormText,
   Input,
   Button,
   Alert,
@@ -186,6 +187,11 @@ function AddNewSparepart() {
               Her indtaster du reservedelens pris uden moms i DKK. Fx 99,95.
             </Tooltip>
           </InputGroup>
+          {price > 0 && (
+            <FormText color="muted">
+              Pris inkl. moms vil blive {price * 1.25} DKK.
+            </FormText>
+          )}
         </FormGroup>
         <FormGroup>
           <InputGroup>

--- a/src/components/editScooter/EditScooter.js
+++ b/src/components/editScooter/EditScooter.js
@@ -9,6 +9,7 @@ import {
   Form,
   InputGroup,
   FormGroup,
+  FormText,
   Input,
   Button,
   Alert,
@@ -29,7 +30,6 @@ export function GetScooterById() {
         _id
         name
         price
-        priceVAT
         sku
         tags
         brand
@@ -289,6 +289,11 @@ function EditScooter(props) {
               Her indtaster du elscooterens pris uden moms i DKK. Fx 22999,95.
             </Tooltip>
           </InputGroup>
+          {price > 0 && (
+            <FormText color="muted">
+              Pris inkl. moms vil blive {price * 1.25} DKK.
+            </FormText>
+          )}
         </FormGroup>
         <FormGroup>
           <InputGroup>

--- a/src/components/editSparepart/EditSparepart.js
+++ b/src/components/editSparepart/EditSparepart.js
@@ -9,6 +9,7 @@ import {
   Form,
   InputGroup,
   FormGroup,
+  FormText,
   Input,
   Button,
   Alert,
@@ -29,7 +30,6 @@ export function GetSparepartById() {
         _id
         name
         price
-        priceVAT
         itemNo
         scooterId
         categoryId
@@ -250,6 +250,11 @@ function EditSparepart(props) {
               Her indtaster du reservedelens pris uden moms i DKK. Fx 99,95.
             </Tooltip>
           </InputGroup>
+          {price > 0 && (
+            <FormText color="muted">
+              Pris inkl. moms vil blive {price * 1.25} DKK.
+            </FormText>
+          )}
         </FormGroup>
         <FormGroup>
           <InputGroup>


### PR DESCRIPTION
Under oprettelse af både elscooter og reservedel samt redigering af disse får man nu oplyst prisen inkl. moms, når man indtaster i inputfeltet.