### PR TITLE
Task 1, 2, 3: Tooltips vises korrekt i Firefox, der er tilføjet DKK ud for alle priserne i produktlisten og InputGroupAddon er tilføjet til felterne under EditScooter- og EditSparepart-komponenterne.

### DIFF
--- a/src/components/addNewScooter/AddNewScooter.js
+++ b/src/components/addNewScooter/AddNewScooter.js
@@ -218,7 +218,7 @@ function AddNewScooter() {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du elscooterens enhedsnummer. Fx AK-3761.
@@ -259,7 +259,7 @@ function AddNewScooter() {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du elscooterens navn. Fx HS-855 Hvid.
@@ -298,7 +298,7 @@ function AddNewScooter() {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du elscooterens pris uden moms i DKK. Fx 22999,95.
@@ -341,7 +341,7 @@ function AddNewScooter() {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du den unikke kode, der identificerer enheden. En
@@ -380,7 +380,7 @@ function AddNewScooter() {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du de ord, der kan identificere enheden. Ordene
@@ -419,7 +419,7 @@ function AddNewScooter() {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du elscooterens mærke. Fx C.T.M.
@@ -460,7 +460,7 @@ function AddNewScooter() {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du en fyldestgørende beskrivelse af enheden. Max 200

--- a/src/components/addNewSparepart/AddNewSparepart.js
+++ b/src/components/addNewSparepart/AddNewSparepart.js
@@ -134,7 +134,7 @@ function AddNewSparepart() {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du reservedelens enhedsnummer. Fx HL-372761.
@@ -175,7 +175,7 @@ function AddNewSparepart() {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du reservedelens enhedsnavn. Fx Armlæn Højre.
@@ -214,7 +214,7 @@ function AddNewSparepart() {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du reservedelens pris uden moms i DKK. Fx 99,95.

--- a/src/components/addNewUser/AddNewUser.js
+++ b/src/components/addNewUser/AddNewUser.js
@@ -236,7 +236,7 @@ function AddNewUser() {
               toggle={toggleAdminRole}
               style={{
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Bemærk! Hvis du checker af i dette felt, så bliver brugeren

--- a/src/components/editScooter/EditScooter.css
+++ b/src/components/editScooter/EditScooter.css
@@ -1,1 +1,17 @@
 @import url('../../assets/css/globalStyles.css');
+
+.inputGroupTextStyles {
+  margin-bottom: 0.5rem;
+  color: #1a1a1a !important;
+  background-color: #f8f8f8 !important;
+  border: 1px #f0f6ea solid !important;
+  border-radius: 0.4rem 0 0 0.4rem !important;
+  box-shadow: 1px 1px 2px #ececec;
+}
+
+.inputStylesEditScooter {
+  border: 1px #f0f6ea solid !important;
+  border-radius: 0 0.4rem 0.4rem 0 !important;
+  box-shadow: 1px 1px 2px #ececec;
+  margin-bottom: 0.5rem;
+}

--- a/src/components/editScooter/EditScooter.js
+++ b/src/components/editScooter/EditScooter.js
@@ -284,7 +284,7 @@ function EditScooter(props) {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du elscooterens enhedsnummer. Fx AK-3761.
@@ -325,7 +325,7 @@ function EditScooter(props) {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du elscooterens navn. Fx HS-855 Hvid.
@@ -366,7 +366,7 @@ function EditScooter(props) {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du elscooterens pris uden moms i DKK. Fx 22999,95.
@@ -409,7 +409,7 @@ function EditScooter(props) {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du den unikke kode, der identificerer enheden. En
@@ -448,7 +448,7 @@ function EditScooter(props) {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du de ord, der kan identificere enheden. Ordene
@@ -487,7 +487,7 @@ function EditScooter(props) {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du elscooterens mærke. Fx C.T.M.
@@ -528,7 +528,7 @@ function EditScooter(props) {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du en fyldestgørende beskrivelse af enheden. Max 200

--- a/src/components/editScooter/EditScooter.js
+++ b/src/components/editScooter/EditScooter.js
@@ -252,9 +252,17 @@ function EditScooter(props) {
       <Form className="form" onSubmit={handleSubmit}>
         <FormGroup>
           <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText
+                className="inputGroupTextStyles"
+                style={{ minWidth: '8.7rem' }}
+              >
+                Enhedsnummer
+              </InputGroupText>
+            </InputGroupAddon>
             <Input
               required
-              className="inputStyles"
+              className="inputStylesEditScooter"
               type="text"
               name="itemNo"
               id="scooterItemNo"
@@ -293,9 +301,17 @@ function EditScooter(props) {
         </FormGroup>
         <FormGroup>
           <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText
+                className="inputGroupTextStyles"
+                style={{ minWidth: '8.7rem' }}
+              >
+                Enhedsnavn
+              </InputGroupText>
+            </InputGroupAddon>
             <Input
               required
-              className="inputStyles"
+              className="inputStylesEditScooter"
               type="text"
               name="name"
               id="scooterName"
@@ -334,8 +350,16 @@ function EditScooter(props) {
         </FormGroup>
         <FormGroup>
           <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText
+                className="inputGroupTextStyles"
+                style={{ minWidth: '8.7rem' }}
+              >
+                Pris uden moms
+              </InputGroupText>
+            </InputGroupAddon>
             <Input
-              className="inputStyles"
+              className="inputStylesEditScooter"
               type="number"
               step={0.01}
               name="price"
@@ -380,8 +404,16 @@ function EditScooter(props) {
         </FormGroup>
         <FormGroup>
           <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText
+                className="inputGroupTextStyles"
+                style={{ minWidth: '8.7rem' }}
+              >
+                SKU
+              </InputGroupText>
+            </InputGroupAddon>
             <Input
-              className="inputStyles"
+              className="inputStylesEditScooter"
               type="text"
               name="sku"
               id="scooterSku"
@@ -419,8 +451,16 @@ function EditScooter(props) {
         </FormGroup>
         <FormGroup>
           <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText
+                className="inputGroupTextStyles"
+                style={{ minWidth: '8.7rem' }}
+              >
+                Tags
+              </InputGroupText>
+            </InputGroupAddon>
             <Input
-              className="inputStyles"
+              className="inputStylesEditScooter"
               type="text"
               name="tags"
               id="scooterTags"
@@ -458,8 +498,16 @@ function EditScooter(props) {
         </FormGroup>
         <FormGroup>
           <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText
+                className="inputGroupTextStyles"
+                style={{ minWidth: '8.7rem' }}
+              >
+                Mærke
+              </InputGroupText>
+            </InputGroupAddon>
             <Input
-              className="inputStyles"
+              className="inputStylesEditScooter"
               type="text"
               name="brand"
               id="scooterBrand"

--- a/src/components/editSparepart/EditSparepart.css
+++ b/src/components/editSparepart/EditSparepart.css
@@ -1,1 +1,17 @@
 @import url('../../assets/css/globalStyles.css');
+
+.inputGroupTextStyles {
+  margin-bottom: 0.5rem;
+  color: #1a1a1a !important;
+  background-color: #f8f8f8 !important;
+  border: 1px #f0f6ea solid !important;
+  border-radius: 0.4rem 0 0 0.4rem !important;
+  box-shadow: 1px 1px 2px #ececec;
+}
+
+.inputStylesEditSparepart {
+  border: 1px #f0f6ea solid !important;
+  border-radius: 0 0.4rem 0.4rem 0 !important;
+  box-shadow: 1px 1px 2px #ececec;
+  margin-bottom: 0.5rem;
+}

--- a/src/components/editSparepart/EditSparepart.js
+++ b/src/components/editSparepart/EditSparepart.js
@@ -191,7 +191,7 @@ function EditSparepart(props) {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du reservedelens enhedsnummer. Fx HL-372761.
@@ -232,7 +232,7 @@ function EditSparepart(props) {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du reservedelens enhedsnavn. Fx Armlæn Højre.
@@ -273,7 +273,7 @@ function EditSparepart(props) {
               style={{
                 padding: '0.5rem',
                 whiteSpace: 'nowrap',
-                minWidth: 'fit-content'
+                minWidth: 'min-content'
               }}
             >
               Her indtaster du reservedelens pris uden moms i DKK. Fx 99,95.

--- a/src/components/editSparepart/EditSparepart.js
+++ b/src/components/editSparepart/EditSparepart.js
@@ -159,9 +159,17 @@ function EditSparepart(props) {
       <Form className="form" onSubmit={handleSubmit}>
         <FormGroup>
           <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText
+                className="inputGroupTextStyles"
+                style={{ minWidth: '8.7rem' }}
+              >
+                Enhedsnummer
+              </InputGroupText>
+            </InputGroupAddon>
             <Input
               required
-              className="inputStyles"
+              className="inputStylesEditSparepart"
               type="text"
               name="itemNo"
               id="sparepartItemNo"
@@ -200,9 +208,17 @@ function EditSparepart(props) {
         </FormGroup>
         <FormGroup>
           <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText
+                className="inputGroupTextStyles"
+                style={{ minWidth: '8.7rem' }}
+              >
+                Enhedsnavn
+              </InputGroupText>
+            </InputGroupAddon>
             <Input
               required
-              className="inputStyles"
+              className="inputStylesEditSparepart"
               type="text"
               name="name"
               id="sparepartName"
@@ -241,8 +257,16 @@ function EditSparepart(props) {
         </FormGroup>
         <FormGroup>
           <InputGroup>
+            <InputGroupAddon addonType="prepend">
+              <InputGroupText
+                className="inputGroupTextStyles"
+                style={{ minWidth: '8.7rem' }}
+              >
+                Pris uden moms
+              </InputGroupText>
+            </InputGroupAddon>
             <Input
-              className="inputStyles"
+              className="inputStylesEditSparepart"
               type="number"
               step={0.01}
               name="price"

--- a/src/components/products/ScooterRows.js
+++ b/src/components/products/ScooterRows.js
@@ -52,12 +52,12 @@ function ScooterRows() {
         </td>
         <td>
           <Link to={`/editScooter/${_id}`} className="linkStyles">
-            {price}
+            {price} DKK
           </Link>
         </td>
         <td>
           <Link to={`/editScooter/${_id}`} className="linkStyles">
-            {priceVAT}
+            {priceVAT} DKK
           </Link>
         </td>
         <td>

--- a/src/components/products/SparepartRows.js
+++ b/src/components/products/SparepartRows.js
@@ -52,12 +52,12 @@ function SparepartRows() {
         </td>
         <td>
           <Link to={`/editSparepart/${_id}`} className="linkStyles">
-            {price}
+            {price} DKK
           </Link>
         </td>
         <td>
           <Link to={`/editSparepart/${_id}`} className="linkStyles">
-            {priceVAT}
+            {priceVAT} DKK
           </Link>
         </td>
         <td>


### PR DESCRIPTION
Tooltips vises korrekt i Firefox, der er tilføjet DKK ud for alle priserne i produktlisten og InputGroupAddon er tilføjet til felterne under EditScooter- og EditSparepart-komponenterne.