### PR TITLE
Hotfix: Hentning af kategorier på splittegninger

### DIFF
--- a/src/components/categories/AddNewSubCategory.js
+++ b/src/components/categories/AddNewSubCategory.js
@@ -3,7 +3,7 @@ import { useMutation } from '@apollo/react-hooks';
 import { gql } from 'apollo-boost';
 import client from '../../config/apolloClient';
 import s3 from '../../config/spacesConfig';
-import GetCategories from './GetCategories';
+import { GetCategoriesById } from './GetCategories';
 
 // Importér Reactstrap komponenter
 import {
@@ -140,7 +140,7 @@ function AddNewSubCategory() {
         </FormGroup>
         <FormGroup>
           <InputGroup>
-            <GetCategories />
+            <GetCategoriesById />
           </InputGroup>
         </FormGroup>
         <FormGroup>

--- a/src/components/categories/EditSubCategory.js
+++ b/src/components/categories/EditSubCategory.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useMutation, useQuery } from '@apollo/react-hooks';
 import { gql } from 'apollo-boost';
 import s3 from '../../config/spacesConfig';
-import { GetCategoriesNotRequired } from './GetCategories.js';
+import { GetCategoriesByIdNotRequired } from './GetCategories.js';
 import GetCategoryName from './GetCategoryName.js';
 
 // Importér Reactstrap komponenter
@@ -241,9 +241,9 @@ function EditSubCategory() {
         <Collapse isOpen={categorySwitchOpen}>
           {inputId === _id && (
             <div className="mb-2">
-              <GetCategoriesNotRequired
+              <GetCategoriesByIdNotRequired
                 parentCallback={handleCategoryId}
-              ></GetCategoriesNotRequired>
+              ></GetCategoriesByIdNotRequired>
             </div>
           )}
         </Collapse>

--- a/src/components/categories/GetCategories.js
+++ b/src/components/categories/GetCategories.js
@@ -95,5 +95,111 @@ export function GetCategoriesNotRequired(props) {
     </Input>
   );
 }
+// Komponent, der renderer to udvalgte kategorier i databasen
+export function GetCategoriesById(props) {
+  // Definér query til at hente kategorier ud fra ID'er
+  const GET_CATEGORIES_BY_IDS = gql`
+    {
+      getCategoriesByIds(
+        input: [
+          { _id: "5dea20b6452dd0511c74b87e" }
+          { _id: "5df34ec47d346542bc0d34db" }
+        ]
+      ) {
+        _id
+        name
+      }
+    }
+  `;
 
+  // Anvend query
+  const { loading, error, data } = useQuery(GET_CATEGORIES_BY_IDS);
+
+  if (loading) return <p className="text-center m-3">Loading...</p>;
+  if (error) return <p className="text-center m-3">Error!</p>;
+
+  // Funktion til at sende data til parent-komponent vha. props
+  const sendDate = event => {
+    if (props.parentCallback) {
+      props.parentCallback(event.target.value);
+    }
+  };
+
+  // Returnerer et select-input med kategorierne som options
+  return (
+    <Input
+      required
+      className="inputStyles"
+      type="select"
+      name="selectCategory"
+      id="chosenCategoryId"
+      onChange={sendDate}
+    >
+      <option value="" disabled selected>
+        Vælg kategori...
+      </option>
+      {data.getCategoriesByIds.map((category, index) => {
+        const { _id, name } = category; // Destructuring
+        return (
+          <option key={_id} value={_id}>
+            {name}
+          </option>
+        );
+      })}
+    </Input>
+  );
+}
+// Komponent, der renderer to udvalgte kategorier i databasen
+export function GetCategoriesByIdNotRequired(props) {
+  // Definér query til at hente kategorier ud fra ID'er
+  const GET_CATEGORIES_BY_IDS = gql`
+    {
+      getCategoriesByIds(
+        input: [
+          { _id: "5dea20b6452dd0511c74b87e" }
+          { _id: "5df34ec47d346542bc0d34db" }
+        ]
+      ) {
+        _id
+        name
+      }
+    }
+  `;
+
+  // Anvend query
+  const { loading, error, data } = useQuery(GET_CATEGORIES_BY_IDS);
+
+  if (loading) return <p className="text-center m-3">Loading...</p>;
+  if (error) return <p className="text-center m-3">Error!</p>;
+
+  // Funktion til at sende data til parent-komponent vha. props
+  const sendDate = event => {
+    if (props.parentCallback) {
+      props.parentCallback(event.target.value);
+    }
+  };
+
+  // Returnerer et select-input med kategorierne som options
+  return (
+    <Input
+      className="inputStyles"
+      type="select"
+      name="selectCategory"
+      id="chosenCategoryId"
+      onChange={sendDate}
+    >
+      <option value="" disabled selected>
+        Vælg kategori...
+      </option>
+      {data.getCategoriesByIds.map((category, index) => {
+        const { _id, name } = category; // Destructuring
+        return (
+          <option key={_id} value={_id}>
+            {name}
+          </option>
+        );
+      })}
+    </Input>
+  );
+}
 export default GetCategories;

--- a/src/components/categories/GetCategories.js
+++ b/src/components/categories/GetCategories.js
@@ -95,6 +95,7 @@ export function GetCategoriesNotRequired(props) {
     </Input>
   );
 }
+
 // Komponent, der renderer to udvalgte kategorier i databasen
 export function GetCategoriesById(props) {
   // Definér query til at hente kategorier ud fra ID'er
@@ -149,6 +150,7 @@ export function GetCategoriesById(props) {
     </Input>
   );
 }
+
 // Komponent, der renderer to udvalgte kategorier i databasen
 export function GetCategoriesByIdNotRequired(props) {
   // Definér query til at hente kategorier ud fra ID'er
@@ -202,4 +204,5 @@ export function GetCategoriesByIdNotRequired(props) {
     </Input>
   );
 }
+
 export default GetCategories;

--- a/src/components/products/Products.js
+++ b/src/components/products/Products.js
@@ -66,7 +66,7 @@ function Products() {
         id="filterInput"
         className="inputStyles mb-3"
         onKeyUp={filterProducts}
-        placeholder="Søg efter enhedsnummer..."
+        placeholder="Søg efter enhedsnavn..."
       />
       <div className="tableScrollView fadeIn">
         <Table id="productList" responsive borderless>


### PR DESCRIPTION
Nu køres en anden mutation som kun henter de to udvalgte modeller, når man skal vælge kategori til en splittegning.